### PR TITLE
[FEAT] 사용자 맞춤 추천 API 기본 구조 구현

### DIFF
--- a/src/main/java/io/github/bon/wonx/controller/MainController.java
+++ b/src/main/java/io/github/bon/wonx/controller/MainController.java
@@ -32,4 +32,12 @@ public class MainController {
     return mainService.getUpcomingVideosWithinAWeek();
   }
 
+  // 인기콘텐츠용: 조회수 기준 인기 콘텐츠를 조회
+  @GetMapping("/wonx-popular")
+  public List<Video> getPopular(
+      // 기본적으로 인기 콘텐츠 5개를 가져오고 요청 파라미터로 갯수 조절?
+      @RequestParam(defaultValue = "5") int count) {
+    return mainService.getPopularVideos(count);
+  }
+
 }

--- a/src/main/java/io/github/bon/wonx/controller/MainController.java
+++ b/src/main/java/io/github/bon/wonx/controller/MainController.java
@@ -1,0 +1,24 @@
+package io.github.bon.wonx.controller;
+
+import io.github.bon.wonx.domain.video.Video;
+import io.github.bon.wonx.service.MainService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/main")
+public class MainController {
+  private final MainService mainService;
+
+  public MainController(MainService mainService) {
+    this.mainService = mainService;
+  }
+
+  // 메인 배너 콘텐츠 응답
+  @GetMapping("/banner")
+  public Video getMainBanner() {
+    return mainService.getMainBannerVideo();
+
+  }
+}

--- a/src/main/java/io/github/bon/wonx/controller/MainController.java
+++ b/src/main/java/io/github/bon/wonx/controller/MainController.java
@@ -4,6 +4,7 @@ import io.github.bon.wonx.domain.video.Video;
 import io.github.bon.wonx.service.MainService;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,25 +20,28 @@ public class MainController {
     this.mainService = mainService;
   }
 
-  // 배너용: 평점 가장 높은 영상 1개
   @GetMapping("/banner")
   public Video getMainBanner() {
     return mainService.getMainBannerVideo();
 
   }
 
-  // 최신작용: 오늘 ~ 7일 내 공개 예정 콘텐츠
   @GetMapping("/latest")
   public List<Video> getLatest() {
     return mainService.getUpcomingVideosWithinAWeek();
   }
 
-  // 인기콘텐츠용: 조회수 기준 인기 콘텐츠를 조회
   @GetMapping("/wonx-popular")
   public List<Video> getPopular(
-      // 기본적으로 인기 콘텐츠 5개를 가져오고 요청 파라미터로 갯수 조절?
       @RequestParam(defaultValue = "5") int count) {
     return mainService.getPopularVideos(count);
+  }
+
+  // 사용자 맞춤 추천 api
+  @GetMapping("/recommend")
+  public List<Video> getRecommend(@RequestParam UUID userId) {
+    // 클라이언트가 userId를 쿼리 파라미터로 전달해야 함
+    return mainService.getRecommendedVideo(userId);
   }
 
 }

--- a/src/main/java/io/github/bon/wonx/controller/MainController.java
+++ b/src/main/java/io/github/bon/wonx/controller/MainController.java
@@ -2,9 +2,13 @@ package io.github.bon.wonx.controller;
 
 import io.github.bon.wonx.domain.video.Video;
 import io.github.bon.wonx.service.MainService;
+
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @RequestMapping("/api/main")
@@ -15,10 +19,17 @@ public class MainController {
     this.mainService = mainService;
   }
 
-  // 메인 배너 콘텐츠 응답
+  // 배너용: 평점 가장 높은 영상 1개
   @GetMapping("/banner")
   public Video getMainBanner() {
     return mainService.getMainBannerVideo();
 
   }
+
+  // 최신작용: 오늘 ~ 7일 내 공개 예정 콘텐츠
+  @GetMapping("/latest")
+  public List<Video> getLatest() {
+    return mainService.getUpcomingVideosWithinAWeek();
+  }
+
 }

--- a/src/main/java/io/github/bon/wonx/domain/video/Video.java
+++ b/src/main/java/io/github/bon/wonx/domain/video/Video.java
@@ -2,8 +2,12 @@ package io.github.bon.wonx.domain.video;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import lombok.Getter;
+
+import java.time.LocalDate;
 import java.util.UUID;
 
+@Getter
 @Entity
 public class Video {
 
@@ -14,7 +18,7 @@ public class Video {
   private String description; // 콘텐츠 설명
   private Float rating; // 콘텐츠 평점
   private Integer durationMinutes; // 영상 길이
-  private String releaseDate; // 출시일
+  private LocalDate releaseDate; // 출시일
   private String ageRating; // 시청 등급
   private String backgroundVideoUrl; // 배너 등에 쓰일 영상 배경 URL
   private String thumbnailUrl; // 썸네일 이미지 URL

--- a/src/main/java/io/github/bon/wonx/domain/video/Video.java
+++ b/src/main/java/io/github/bon/wonx/domain/video/Video.java
@@ -1,0 +1,22 @@
+package io.github.bon.wonx.domain.video;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.util.UUID;
+
+@Entity
+public class Video {
+
+  @Id
+  private UUID id; // 콘텐츠 고유 식별자
+
+  private String title; // 콘텐츠 제목
+  private String description; // 콘텐츠 설명
+  private Float rating; // 콘텐츠 평점
+  private Integer durationMinutes; // 영상 길이
+  private String releaseDate; // 출시일
+  private String ageRating; // 시청 등급
+  private String backgroundVideoUrl; // 배너 등에 쓰일 영상 배경 URL
+  private String thumbnailUrl; // 썸네일 이미지 URL
+
+}

--- a/src/main/java/io/github/bon/wonx/domain/video/Video.java
+++ b/src/main/java/io/github/bon/wonx/domain/video/Video.java
@@ -22,5 +22,5 @@ public class Video {
   private String ageRating; // 시청 등급
   private String backgroundVideoUrl; // 배너 등에 쓰일 영상 배경 URL
   private String thumbnailUrl; // 썸네일 이미지 URL
-
+  private Integer viewCount; // 콘텐츠 조회수
 }

--- a/src/main/java/io/github/bon/wonx/domain/video/Video.java
+++ b/src/main/java/io/github/bon/wonx/domain/video/Video.java
@@ -23,4 +23,6 @@ public class Video {
   private String backgroundVideoUrl; // 배너 등에 쓰일 영상 배경 URL
   private String thumbnailUrl; // 썸네일 이미지 URL
   private Integer viewCount; // 콘텐츠 조회수
+  private Long tmdbId; // TMDb에서 받은 고유 ID
+  private String genre; // TMDb에서 받은 장르
 }

--- a/src/main/java/io/github/bon/wonx/domain/video/VideoRepository.java
+++ b/src/main/java/io/github/bon/wonx/domain/video/VideoRepository.java
@@ -1,0 +1,10 @@
+package io.github.bon.wonx.domain.video;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface VideoRepository extends JpaRepository<Video, UUID> {
+  List<Video> findTop1ByOrderByRatingDesc(); // 평점 높은 콘텐츠를 1개 가져오기 위함 -> service에서 이걸 호출
+}

--- a/src/main/java/io/github/bon/wonx/domain/video/VideoRepository.java
+++ b/src/main/java/io/github/bon/wonx/domain/video/VideoRepository.java
@@ -2,9 +2,15 @@ package io.github.bon.wonx.domain.video;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public interface VideoRepository extends JpaRepository<Video, UUID> {
-  List<Video> findTop1ByOrderByRatingDesc(); // 평점 높은 콘텐츠를 1개 가져오기 위함 -> service에서 이걸 호출
+  // 배너용 콘텐츠 1개 가져오기
+  List<Video> findTop1ByOrderByRatingDesc();
+
+  // 오늘 날짜 기준 1주일 이내에 공개될 콘텐츠만 보여주기
+  List<Video> findByReleaseDateBetweenOrderByReleaseDateAsc(LocalDate start, LocalDate end);
+
 }

--- a/src/main/java/io/github/bon/wonx/domain/video/VideoRepository.java
+++ b/src/main/java/io/github/bon/wonx/domain/video/VideoRepository.java
@@ -1,5 +1,6 @@
 package io.github.bon.wonx.domain.video;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -13,4 +14,6 @@ public interface VideoRepository extends JpaRepository<Video, UUID> {
   // 오늘 날짜 기준 1주일 이내에 공개될 콘텐츠만 보여주기
   List<Video> findByReleaseDateBetweenOrderByReleaseDateAsc(LocalDate start, LocalDate end);
 
+  // 조회수 기준 인기 콘텐츠를 정렬하기
+  List<Video> findAllByOrderByViewCountDesc(Pageable pageable);
 }

--- a/src/main/java/io/github/bon/wonx/service/MainService.java
+++ b/src/main/java/io/github/bon/wonx/service/MainService.java
@@ -4,6 +4,7 @@ import io.github.bon.wonx.domain.video.Video;
 import io.github.bon.wonx.domain.video.VideoRepository;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -17,5 +18,11 @@ public class MainService {
   public Video getMainBannerVideo() {
     List<Video> topVideo = videoRepository.findTop1ByOrderByRatingDesc();
     return topVideo.isEmpty() ? null : topVideo.get(0);
+  }
+
+  public List<Video> getUpcomingVideosWithinAWeek() {
+    LocalDate today = LocalDate.now(); // 오늘 기준
+    LocalDate weekLater = today.plusDays(7); // 일주일 이내에 공개 예정인 영상 목록
+    return videoRepository.findByReleaseDateBetweenOrderByReleaseDateAsc(today, weekLater);
   }
 }

--- a/src/main/java/io/github/bon/wonx/service/MainService.java
+++ b/src/main/java/io/github/bon/wonx/service/MainService.java
@@ -2,7 +2,10 @@ package io.github.bon.wonx.service;
 
 import io.github.bon.wonx.domain.video.Video;
 import io.github.bon.wonx.domain.video.VideoRepository;
+
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,5 +27,10 @@ public class MainService {
     LocalDate today = LocalDate.now(); // 오늘 기준
     LocalDate weekLater = today.plusDays(7); // 일주일 이내에 공개 예정인 영상 목록
     return videoRepository.findByReleaseDateBetweenOrderByReleaseDateAsc(today, weekLater);
+  }
+
+  public List<Video> getPopularVideos(int count) {
+    Pageable pageable = PageRequest.of(0, count);
+    return videoRepository.findAllByOrderByViewCountDesc(pageable);
   }
 }

--- a/src/main/java/io/github/bon/wonx/service/MainService.java
+++ b/src/main/java/io/github/bon/wonx/service/MainService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class MainService {
@@ -18,19 +19,34 @@ public class MainService {
     this.videoRepository = videoRepository;
   }
 
+  // 기존: 배너용 콘텐츠 조회
   public Video getMainBannerVideo() {
     List<Video> topVideo = videoRepository.findTop1ByOrderByRatingDesc();
     return topVideo.isEmpty() ? null : topVideo.get(0);
   }
 
+  // 기존: 1주일 이내 개봉 콘텐츠
   public List<Video> getUpcomingVideosWithinAWeek() {
     LocalDate today = LocalDate.now(); // 오늘 기준
     LocalDate weekLater = today.plusDays(7); // 일주일 이내에 공개 예정인 영상 목록
     return videoRepository.findByReleaseDateBetweenOrderByReleaseDateAsc(today, weekLater);
   }
 
+  // 기존: 조회수 기준 인기 콘텐츠
   public List<Video> getPopularVideos(int count) {
     Pageable pageable = PageRequest.of(0, count);
     return videoRepository.findAllByOrderByViewCountDesc(pageable);
+  }
+
+  // 추가: 사용자 맞춤 추천 api (현재는 더미)
+  public List<Video> getRecommendedVideo(UUID userId) {
+    // 나중에 여기에 TMDB 연동 기반 로직을 추가할 예정
+    // 1. userId 기반으로 사용자가 좋아요 누른 콘텐츠 or 평점 준 콘텐츠 조회
+    // 2. 그 콘텐츠들의 TMBD ID로 연관 추천 요청 -> 유사한 콘텐츠 받아오기 (장르?)
+    // 3. 응답 결과를 바탕으로 엔티티로 저장 혹은 추천 DTO로 반환
+
+    // 지금은 일단 임시로 상위 5개 랜덤 반환
+    Pageable pageable = PageRequest.of(0, 5); // 지금은 임시로 상위 5개 랜덤 반환
+    return videoRepository.findAll(pageable).getContent();
   }
 }

--- a/src/main/java/io/github/bon/wonx/service/MainService.java
+++ b/src/main/java/io/github/bon/wonx/service/MainService.java
@@ -1,0 +1,21 @@
+package io.github.bon.wonx.service;
+
+import io.github.bon.wonx.domain.video.Video;
+import io.github.bon.wonx.domain.video.VideoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MainService {
+  private final VideoRepository videoRepository;
+
+  public MainService(VideoRepository videoRepository) {
+    this.videoRepository = videoRepository;
+  }
+
+  public Video getMainBannerVideo() {
+    List<Video> topVideo = videoRepository.findTop1ByOrderByRatingDesc();
+    return topVideo.isEmpty() ? null : topVideo.get(0);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+# SQL 초기화 파일(data.sql) 실행 허용
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,21 +1,9 @@
 INSERT INTO video (
-  id,
-  title,
-  description,
-  rating,
-  duration_minutes,
-  release_date,
-  age_rating,
-  background_video_url,
-  thumbnail_url
-) VALUES (
-  RANDOM_UUID(),
-  '테스트 콘텐츠',
-  '테스트용 설명입니다.',
-  4.5,
-  110,
-  CURRENT_DATE + 3,
-  '15+',
-  'https://example.com/bg.mp4',
-  'https://example.com/thumb.jpg'
-);
+  id, title, description, rating, duration_minutes,
+  release_date, age_rating, background_video_url,
+  thumbnail_url, view_count
+) VALUES
+  (RANDOM_UUID(), '해리포터', '마법 세계 이야기', 4.8, 120, CURRENT_DATE, '12+', 'https://example.com/bg1.mp4', 'https://example.com/thumb1.jpg', 500),
+  (RANDOM_UUID(), '반지의 제왕', '모험 판타지', 4.9, 180, CURRENT_DATE, '15+', 'https://example.com/bg2.mp4', 'https://example.com/thumb2.jpg', 1200),
+  (RANDOM_UUID(), '인사이드 아웃', '감정의 세계', 4.5, 100, CURRENT_DATE, 'All', 'https://example.com/bg3.mp4', 'https://example.com/thumb3.jpg', 800),
+  (RANDOM_UUID(), '겨울왕국', '엘사 이야기', 4.7, 110, CURRENT_DATE, 'All', 'https://example.com/bg4.mp4', 'https://example.com/thumb4.jpg', 950);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,9 +1,19 @@
 INSERT INTO video (
-  id, title, description, rating, duration_minutes,
-  release_date, age_rating, background_video_url,
-  thumbnail_url, view_count
+  id,
+  title,
+  description,
+  rating,
+  duration_minutes,
+  release_date,
+  age_rating,
+  background_video_url,
+  thumbnail_url,
+  view_count,
+  tmdb_id,
+  genre
 ) VALUES
-  (RANDOM_UUID(), '해리포터', '마법 세계 이야기', 4.8, 120, CURRENT_DATE, '12+', 'https://example.com/bg1.mp4', 'https://example.com/thumb1.jpg', 500),
-  (RANDOM_UUID(), '반지의 제왕', '모험 판타지', 4.9, 180, CURRENT_DATE, '15+', 'https://example.com/bg2.mp4', 'https://example.com/thumb2.jpg', 1200),
-  (RANDOM_UUID(), '인사이드 아웃', '감정의 세계', 4.5, 100, CURRENT_DATE, 'All', 'https://example.com/bg3.mp4', 'https://example.com/thumb3.jpg', 800),
-  (RANDOM_UUID(), '겨울왕국', '엘사 이야기', 4.7, 110, CURRENT_DATE, 'All', 'https://example.com/bg4.mp4', 'https://example.com/thumb4.jpg', 950);
+  (RANDOM_UUID(), '인사이드 아웃', '감정들의 모험', 4.7, 95, CURRENT_DATE, 'All', 'https://example.com/bg1.mp4', 'https://example.com/thumb1.jpg', 1000, 150540, 'Animation, Family'),
+  (RANDOM_UUID(), '겨울왕국', '얼음 여왕의 이야기', 4.8, 102, CURRENT_DATE, 'All', 'https://example.com/bg2.mp4', 'https://example.com/thumb2.jpg', 850, 109445, 'Animation, Adventure'),
+  (RANDOM_UUID(), '라푼젤', '탑에 갇힌 공주 이야기', 4.6, 100, CURRENT_DATE, 'All', 'https://example.com/bg3.mp4', 'https://example.com/thumb3.jpg', 920, 38757, 'Animation, Romance'),
+  (RANDOM_UUID(), '코코', '죽은 자의 세계 모험', 4.9, 105, CURRENT_DATE, 'All', 'https://example.com/bg4.mp4', 'https://example.com/thumb4.jpg', 880, 354912, 'Animation, Music'),
+  (RANDOM_UUID(), '업', '하늘을 나는 집 이야기', 4.5, 96, CURRENT_DATE, 'All', 'https://example.com/bg5.mp4', 'https://example.com/thumb5.jpg', 970, 14160, 'Animation, Comedy');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,21 @@
+INSERT INTO video (
+  id,
+  title,
+  description,
+  rating,
+  duration_minutes,
+  release_date,
+  age_rating,
+  background_video_url,
+  thumbnail_url
+) VALUES (
+  RANDOM_UUID(),
+  '테스트 콘텐츠',
+  '테스트용 설명입니다.',
+  4.5,
+  110,
+  CURRENT_DATE + 3,
+  '15+',
+  'https://example.com/bg.mp4',
+  'https://example.com/thumb.jpg'
+);


### PR DESCRIPTION
**# 구현 기능**
- 사용자 ID 기반 추천 API 구조 구현 (`/api/main/recommend`)
- 현재는 랜덤 콘텐츠 추천 (임시), 나중에 TMDb 연동 예정
- 추천 로직은 userId 기반 구조에 맞춰 확장 가능하게 설계함

**# 구현 상태**
- 테스트용 더미 데이터로 API 정상 작동 확인
- UUID 쿼리 파라미터로 요청 가능
- `/recommend?userId=...` 방식 확인 완료